### PR TITLE
Allow diffs to other git branches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
+src/copychat/_version.py

--- a/README.md
+++ b/README.md
@@ -100,9 +100,14 @@ copychat --diff-mode full-with-diff
 
 # Show only the git diff chunks themselves
 copychat --diff-mode diff-only
+
+# See what changed since branching from develop
+copychat --diff-mode diff-only --diff-branch develop
 ```
 
-This is particularly useful when you want to discuss code changes with an LLM.
+The `-diff-mode` and `--diff-branch` options are particularly useful when you want to:
+- Review any changes you've made, either in isolation or in context
+- Compare changes against a specific branch
 
 ### Excluding Files
 
@@ -189,6 +194,7 @@ Options:
   -x, --exclude TEXT    Glob patterns to exclude
   -d, --depth INTEGER   Maximum directory depth to scan (0 = current dir only)
   --diff-mode TEXT     How to handle git diffs
+  --diff-branch TEXT Compare changes against specified branch
   --debug              Debug mode for development
   --help               Show this message and exit
 ```

--- a/src/copychat/cli.py
+++ b/src/copychat/cli.py
@@ -133,7 +133,6 @@ def main(
     compare_branch: Optional[str] = typer.Option(
         None,
         "--diff-branch",
-        "-b",
         help="Compare changes against specified branch instead of working directory",
     ),
 ) -> None:

--- a/src/copychat/cli.py
+++ b/src/copychat/cli.py
@@ -130,6 +130,12 @@ def main(
         "--debug",
         help="Debug mode for development",
     ),
+    compare_branch: Optional[str] = typer.Option(
+        None,
+        "--diff-branch",
+        "-b",
+        help="Compare changes against specified branch instead of working directory",
+    ),
 ) -> None:
     """Convert source code files to markdown format for LLM context."""
     if version:
@@ -162,7 +168,9 @@ def main(
 
         # Handle file vs directory source
         if source_dir.is_file():
-            content = get_file_content(source_dir, diff_mode)
+            content = get_file_content(
+                source_dir, diff_mode, compare_branch=compare_branch
+            )
             all_files = {source_dir: content} if content is not None else {}
         else:
             # For directories, scan all paths
@@ -176,7 +184,9 @@ def main(
                 if target.is_absolute():
                     # Use absolute paths as-is
                     if target.is_file():
-                        content = get_file_content(target, diff_mode)
+                        content = get_file_content(
+                            target, diff_mode, compare_branch=compare_branch
+                        )
                         if content is not None:
                             all_files[target] = content
                     else:
@@ -186,6 +196,7 @@ def main(
                             exclude_patterns=exclude,
                             diff_mode=diff_mode,
                             max_depth=depth,
+                            compare_branch=compare_branch,
                         )
                         all_files.update(files)
                 else:
@@ -197,7 +208,9 @@ def main(
                     for target in targets:
                         if target.exists():
                             if target.is_file():
-                                content = get_file_content(target, diff_mode)
+                                content = get_file_content(
+                                    target, diff_mode, compare_branch=compare_branch
+                                )
                                 if content is not None:
                                     all_files[target] = content
                                 break
@@ -208,12 +221,13 @@ def main(
                                     exclude_patterns=exclude,
                                     diff_mode=diff_mode,
                                     max_depth=depth,
+                                    compare_branch=compare_branch,
                                 )
                                 all_files.update(files)
                                 break
         if not all_files:
             error_console.print("Found [red]0[/] matching files")
-            raise typer.Exit(1)  # Exit with code 1 to indicate no files found
+            return
 
         # Format files - pass both paths and content
         format_result = format_files_xml(


### PR DESCRIPTION
This pull request introduces a new feature allowing users to compare changes against a specified branch in the `copychat` tool. The most important changes include updates to the CLI options, enhancements to the core functionality for handling git diffs, and modifications to the file content retrieval process.

### CLI Enhancements:
* Added `--diff-branch` option to the CLI to allow users to specify a branch to compare changes against. (`README.md`, `src/copychat/cli.py`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R103-R110) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R197) [[3]](diffhunk://#diff-2a9446224f301341e920def07cb9b9f61941138e5b1b4e83929b3002d40d392eR133-R137)

### Core Functionality:
* Updated `get_git_diff` function to support comparing against a specified branch. (`src/copychat/core.py`) [[1]](diffhunk://#diff-d1230aead666ada665d15ff52cd879cb5a3792fe611d672e94bf99fdb2ea375bL93-R94) [[2]](diffhunk://#diff-d1230aead666ada665d15ff52cd879cb5a3792fe611d672e94bf99fdb2ea375bL106-R208)
* Enhanced `get_changed_files` to handle changes between the current branch and a specified branch. (`src/copychat/core.py`)

### File Content Retrieval:
* Modified `get_file_content` to accept a `compare_branch` parameter and adjust its logic based on the diff mode and specified branch. (`src/copychat/core.py`)
* Updated `scan_directory` to pass the `compare_branch` parameter when retrieving file content. (`src/copychat/core.py`) [[1]](diffhunk://#diff-d1230aead666ada665d15ff52cd879cb5a3792fe611d672e94bf99fdb2ea375bR252-R258) [[2]](diffhunk://#diff-d1230aead666ada665d15ff52cd879cb5a3792fe611d672e94bf99fdb2ea375bL208-R281) [[3]](diffhunk://#diff-d1230aead666ada665d15ff52cd879cb5a3792fe611d672e94bf99fdb2ea375bL267-R342)