### PR TITLE
Add diff to PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,9 @@ You can also use the full URL:
 copychat https://github.com/owner/repo/issues/123
 ```
 
-Set `GITHUB_TOKEN` or use `--token` if you need to access private issues.
+For pull requests, the diff is included by default, giving you complete context of the proposed changes.
+
+Set `GITHUB_TOKEN` or use `--token` if you need to access private issues or PRs. A token may also provide higher rate limits when fetching PR diffs.
 
 The output is formatted like other files, with XML-style tags.
 

--- a/tests/test_github_item.py
+++ b/tests/test_github_item.py
@@ -2,10 +2,11 @@ from copychat.sources import GitHubItem
 
 
 class DummyResponse:
-    def __init__(self, data, status=200):
+    def __init__(self, data, status=200, is_text=False):
         self._data = data
         self.status_code = status
         self.ok = status == 200
+        self._is_text = is_text
 
     def raise_for_status(self):
         if not self.ok:
@@ -13,6 +14,10 @@ class DummyResponse:
 
     def json(self):
         return self._data
+
+    @property
+    def text(self):
+        return self._data if self._is_text else ""
 
 
 def test_github_item_fetch(monkeypatch):
@@ -63,3 +68,62 @@ def test_github_item_fetch(monkeypatch):
     assert "**Author**: testuser" in content
     assert "https://github.com/owner/repo/pull/1" in content
     assert any("pulls" in c for c in calls)
+
+
+def test_github_item_fetch_with_diff(monkeypatch):
+    """GitHubItem should include PR diff when available."""
+
+    issue_data = {
+        "title": "Test PR",
+        "body": "PR description",
+        "comments_url": "http://example.com/comments",
+        "pull_request": {},
+        "html_url": "https://github.com/owner/repo/pull/2",
+        "user": {"login": "testuser"},
+        "created_at": "2024-01-01",
+        "updated_at": "2024-01-02",
+        "state": "open",
+    }
+    comments = []
+    reviews = []
+    diff_content = """diff --git a/file.txt b/file.txt
+index abc123..def456 100644
+--- a/file.txt
++++ b/file.txt
+@@ -1,3 +1,3 @@
+ Line 1
+-Line 2
++Line 2 modified
+ Line 3"""
+
+    calls = []
+    headers_received = {}
+
+    def fake_get(url, headers=None, timeout=0):
+        calls.append(url)
+        if headers:
+            headers_received[url] = headers
+
+        if "diff" in headers.get("Accept", "") and "pulls" in url:
+            return DummyResponse(diff_content, is_text=True)
+        if "comments" in url and "pulls" in url:
+            return DummyResponse(reviews)
+        if "comments" in url:
+            return DummyResponse(comments)
+        return DummyResponse(issue_data)
+
+    monkeypatch.setattr("requests.get", fake_get)
+
+    item = GitHubItem("owner/repo", 2)
+    path, content = item.fetch()
+
+    assert path.name == "owner_repo_pr_2.md"
+    assert "Test PR" in content
+    assert "PR description" in content
+    assert "**Pull Request**" in content
+    assert "## PR Diff" in content
+    assert "```diff" in content
+    assert "+Line 2 modified" in content
+    assert "application/vnd.github.diff" in headers_received.get(
+        "https://api.github.com/repos/owner/repo/pulls/2", {}
+    ).get("Accept", "")


### PR DESCRIPTION
When loading a github pr (e.g. `copychat https://github.com/jlowin/copychat/pull/17`, include the PR diff)